### PR TITLE
Add Auto Image Fit extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-PicFit
+# PicFit
+
+This repository provides a simple Chromium extension called **Auto Image Fit**. The extension automatically scales and centers standalone images so that they fit the browser viewport.
+
+## How it works
+
+When a tab loads a single image file, the extension injects a content script that adjusts page styles. The image is scaled to the available width or height while keeping its aspect ratio and centered within the viewport.
+
+## Install in developer mode
+
+1. Open `chrome://extensions` in a Chromium-based browser.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select the `extension` directory from this repository.
+
+## Package the extension
+
+To distribute the extension, zip the contents of the `extension` directory and upload the archive to the Chrome Web Store or any other distribution channel.

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,14 @@
+if (document.contentType && document.contentType.startsWith('image/')) {
+	const bodyChildren = document.body.children
+	if (bodyChildren.length === 1 && bodyChildren[0].tagName === 'IMG') {
+		document.documentElement.style.height = '100%'
+		document.body.style.margin = '0'
+		document.body.style.display = 'flex'
+		document.body.style.justifyContent = 'center'
+		document.body.style.alignItems = 'center'
+		const img = bodyChildren[0]
+		img.style.maxWidth = '100vw'
+		img.style.maxHeight = '100vh'
+		img.style.objectFit = 'contain'
+	}
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+    "manifest_version": 3,
+    "name": "Auto Image Fit",
+    "version": "1.0",
+    "description": "Automatically scale and center standalone images.",
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content.js"],
+            "run_at": "document_end"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add a simple Chromium extension that scales standalone images to fit the viewport
- document installation and packaging instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68589be09d808320ac811ed764160976